### PR TITLE
Updates to cert manager to break bolt db dependency

### DIFF
--- a/db.go
+++ b/db.go
@@ -26,7 +26,6 @@ type UserInfo struct {
 }
 
 func db() (*gorm.DB, error) {
-	fmt.Println("Calling to connect to DATABASE!!!!!")
 	db, err := gorm.Open("postgres", "host=localhost port=5432 user=certmanager dbname=certmanager password=Pass1234 sslmode=disable")
 	if err != nil {
 		fmt.Println(err)
@@ -34,7 +33,6 @@ func db() (*gorm.DB, error) {
 	}
 
 	return db, err
-	//defer db.Close()
 }
 
 /**

--- a/db.go
+++ b/db.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+)
+
+type test struct {
+	gorm.Model
+	Cert string
+}
+
+func addCert(name string) {
+	db, err := gorm.Open("postgres", "host=localhost port=5432 user=certmanager dbname=certmanager password=Pass1234 sslmode=disable")
+	if err != nil {
+		fmt.Println(err)
+		panic("failed to connect to certManager database")
+	}
+	defer db.Close()
+	db.AutoMigrate(&test{})
+
+	//Add cert object
+	db.Create(&test{Cert: name})
+
+}
+
+/**
+Get Domain AltNames via domain
+*/
+func getAltNames(domain string) (altNames []byte, err error) {
+	panic("Not Implemented")
+}
+
+/**
+Get User Info via email
+*/
+func getUserInfo(email string) (userInfo []byte, err error) {
+	panic("Not Implemented")
+}
+
+/**
+Get Certificate Details via Domain
+*/
+func getCertDeatils(domain string) (certDetails []byte, err error) {
+	panic("Not Implemented")
+}
+
+/**
+Save User Information key email, value userInfo
+*/
+func addUserInfo(email string, userInfo []byte) error {
+	panic("Not Implemented")
+}
+
+/**
+Save Certificate Details key domain, value certDetails
+*/
+func addCertDetails(domain string, certDetails []byte) error {
+	panic("Not Implemented")
+}
+
+/**
+Save Alt Name Details key domain, value altNames
+*/
+func addAltNames(domain string, altNames []byte) error {
+	panic("Not Implemented")
+}

--- a/db.go
+++ b/db.go
@@ -25,8 +25,8 @@ type UserInfo struct {
 	Value string
 }
 
-func db() (*gorm.DB, error) {
-	db, err := gorm.Open("postgres", "host=localhost port=5432 user=certmanager dbname=certmanager password=Pass1234 sslmode=disable")
+func db(dbArgs string) (*gorm.DB, error) {
+	db, err := gorm.Open("postgres", dbArgs)
 	if err != nil {
 		fmt.Println(err)
 		panic("failed to connect to certManager database")
@@ -38,14 +38,14 @@ func db() (*gorm.DB, error) {
 /**
 Get Domain AltNames via domain
 */
-func getAltNames(domain string) (altNamesRaw []byte, err error) {
+func getAltNames(domain string, d *gorm.DB) (altNamesRaw []byte, err error) {
 	log.Printf("Retreving domain alt-names from database for domain (%s)", domain)
 
-	d, err := db()
+	//d, err := db()
 	var altNames DomainAltname
 
 	d.Where(&DomainAltname{Domain: domain}).First(&altNames)
-	defer d.Close()
+	//defer d.Close()
 
 	altNamesRaw = []byte(altNames.Value)
 	return altNamesRaw, err
@@ -54,14 +54,14 @@ func getAltNames(domain string) (altNamesRaw []byte, err error) {
 /**
 Get User Info via email
 */
-func getUserInfo(email string) (userInfoRaw []byte, err error) {
+func getUserInfo(email string, d *gorm.DB) (userInfoRaw []byte, err error) {
 	log.Printf("Retreving user info email (%s) from database", email)
 
-	d, err := db()
+	//d, err := db()
 	var userInfo UserInfo
 
 	d.Where(&UserInfo{Email: email}).Find(&userInfo)
-	defer d.Close()
+	//defer d.Close()
 
 	userInfoRaw = []byte(userInfo.Value)
 	return userInfoRaw, err
@@ -70,14 +70,14 @@ func getUserInfo(email string) (userInfoRaw []byte, err error) {
 /**
 Get Certificate Details via Domain
 */
-func getCertDetails(domain string) (certDetailsRaw []byte, err error) {
+func getCertDetails(domain string, d *gorm.DB) (certDetailsRaw []byte, err error) {
 	log.Printf("Retreving certificate details from database for domain (%s)", domain)
 
-	d, err := db()
+	//d, err := db()
 	var certDetails CertDetail
 
 	d.Where(&CertDetail{Domain: domain}).First(&certDetails)
-	defer d.Close()
+	//defer d.Close()
 
 	certDetailsRaw = []byte(certDetails.Value)
 	return certDetailsRaw, err
@@ -86,14 +86,14 @@ func getCertDetails(domain string) (certDetailsRaw []byte, err error) {
 /**
 Save User Information key email, value userInfo
 */
-func addUserInfo(email string, userInfo []byte) error {
+func addUserInfo(email string, userInfo []byte, d *gorm.DB) (err error) {
 	log.Printf("Saving user info email (%s) to database", email)
 
-	d, err := db()
+	//d, err := db()
 	s := string(userInfo)
 
 	d.Create(&UserInfo{Email: email, Value: s})
-	defer d.Close()
+	//defer d.Close()
 
 	return err
 }
@@ -101,14 +101,14 @@ func addUserInfo(email string, userInfo []byte) error {
 /**
 Save Certificate Details key domain, value certDetails
 */
-func addCertDetails(domain string, certDetails []byte) error {
+func addCertDetails(domain string, certDetails []byte, d *gorm.DB) (err error) {
 	log.Printf("Saving certificate details to database for domain (%s)", domain)
 
-	d, err := db()
+	//d, err := db()
 	s := string(certDetails)
 
 	d.Create(&CertDetail{Domain: domain, Value: s})
-	defer d.Close()
+	//defer d.Close()
 
 	return err
 }
@@ -116,14 +116,14 @@ func addCertDetails(domain string, certDetails []byte) error {
 /**
 Save Alt Names Details key domain, value altNames
 */
-func addAltNames(domain string, altNames []byte) error {
+func addAltNames(domain string, altNames []byte, d *gorm.DB) (err error) {
 	log.Printf("Saving domain alt-names to database for domain (%s)", domain)
 
-	d, err := db()
+	//d, err := db()
 	s := string(altNames)
 
 	d.Create(&DomainAltname{Domain: domain, Value: s})
-	defer d.Close()
+	//defer d.Close()
 
 	return err
 }
@@ -131,17 +131,17 @@ func addAltNames(domain string, altNames []byte) error {
 /**
 Update Alt Names Details key domain, new values altNames
 */
-func updateAltNames(domain string, altNamesRaw []byte) error {
+func updateAltNames(domain string, altNamesRaw []byte, d *gorm.DB) (err error) {
 	log.Printf("Updating domain alt-names to database for domain (%s)", domain)
 
-	d, err := db()
+	//d, err := db()
 	s := string(altNamesRaw)
 	var altNames DomainAltname
 
 	d.Where(&DomainAltname{Domain: domain}).First(&altNames)
 	altNames.Value = s
 	d.Save(&altNames)
-	defer d.Close()
+	//defer d.Close()
 
 	return err
 }
@@ -149,17 +149,17 @@ func updateAltNames(domain string, altNamesRaw []byte) error {
 /**
 Update Certificate Details key domain, new value certDetails
 */
-func updateCertDetails(domain string, certDetailsRaw []byte) error {
+func updateCertDetails(domain string, certDetailsRaw []byte, d *gorm.DB) (err error) {
 	log.Printf("Updating domain alt-names to database for domain (%s)", domain)
 
-	d, err := db()
+	//d, err := db()
 	s := string(certDetailsRaw)
 	var certDetails CertDetail
 
 	d.Where(&CertDetail{Domain: domain}).First(&certDetails)
 	certDetails.Value = s
 	d.Save(&certDetails)
-	defer d.Close()
+	//defer d.Close()
 
 	return err
 }

--- a/db.go
+++ b/db.go
@@ -41,12 +41,8 @@ Get Domain AltNames via domain
 func getAltNames(domain string, d *gorm.DB) (altNamesRaw []byte, err error) {
 	log.Printf("Retreving domain alt-names from database for domain (%s)", domain)
 
-	//d, err := db()
 	var altNames DomainAltname
-
 	d.Where(&DomainAltname{Domain: domain}).First(&altNames)
-	//defer d.Close()
-
 	altNamesRaw = []byte(altNames.Value)
 	return altNamesRaw, err
 }
@@ -57,12 +53,8 @@ Get User Info via email
 func getUserInfo(email string, d *gorm.DB) (userInfoRaw []byte, err error) {
 	log.Printf("Retreving user info email (%s) from database", email)
 
-	//d, err := db()
 	var userInfo UserInfo
-
 	d.Where(&UserInfo{Email: email}).Find(&userInfo)
-	//defer d.Close()
-
 	userInfoRaw = []byte(userInfo.Value)
 	return userInfoRaw, err
 }
@@ -73,12 +65,8 @@ Get Certificate Details via Domain
 func getCertDetails(domain string, d *gorm.DB) (certDetailsRaw []byte, err error) {
 	log.Printf("Retreving certificate details from database for domain (%s)", domain)
 
-	//d, err := db()
 	var certDetails CertDetail
-
 	d.Where(&CertDetail{Domain: domain}).First(&certDetails)
-	//defer d.Close()
-
 	certDetailsRaw = []byte(certDetails.Value)
 	return certDetailsRaw, err
 }
@@ -89,12 +77,8 @@ Save User Information key email, value userInfo
 func addUserInfo(email string, userInfo []byte, d *gorm.DB) (err error) {
 	log.Printf("Saving user info email (%s) to database", email)
 
-	//d, err := db()
 	s := string(userInfo)
-
 	d.Create(&UserInfo{Email: email, Value: s})
-	//defer d.Close()
-
 	return err
 }
 
@@ -104,12 +88,8 @@ Save Certificate Details key domain, value certDetails
 func addCertDetails(domain string, certDetails []byte, d *gorm.DB) (err error) {
 	log.Printf("Saving certificate details to database for domain (%s)", domain)
 
-	//d, err := db()
 	s := string(certDetails)
-
 	d.Create(&CertDetail{Domain: domain, Value: s})
-	//defer d.Close()
-
 	return err
 }
 
@@ -119,12 +99,8 @@ Save Alt Names Details key domain, value altNames
 func addAltNames(domain string, altNames []byte, d *gorm.DB) (err error) {
 	log.Printf("Saving domain alt-names to database for domain (%s)", domain)
 
-	//d, err := db()
 	s := string(altNames)
-
 	d.Create(&DomainAltname{Domain: domain, Value: s})
-	//defer d.Close()
-
 	return err
 }
 
@@ -134,15 +110,11 @@ Update Alt Names Details key domain, new values altNames
 func updateAltNames(domain string, altNamesRaw []byte, d *gorm.DB) (err error) {
 	log.Printf("Updating domain alt-names to database for domain (%s)", domain)
 
-	//d, err := db()
 	s := string(altNamesRaw)
 	var altNames DomainAltname
-
 	d.Where(&DomainAltname{Domain: domain}).First(&altNames)
 	altNames.Value = s
 	d.Save(&altNames)
-	//defer d.Close()
-
 	return err
 }
 
@@ -152,14 +124,10 @@ Update Certificate Details key domain, new value certDetails
 func updateCertDetails(domain string, certDetailsRaw []byte, d *gorm.DB) (err error) {
 	log.Printf("Updating domain alt-names to database for domain (%s)", domain)
 
-	//d, err := db()
 	s := string(certDetailsRaw)
 	var certDetails CertDetail
-
 	d.Where(&CertDetail{Domain: domain}).First(&certDetails)
 	certDetails.Value = s
 	d.Save(&certDetails)
-	//defer d.Close()
-
 	return err
 }

--- a/db.go
+++ b/db.go
@@ -38,96 +38,134 @@ func db(dbHost string, dbPort string, dbUser string, dbName string, dbPassword s
 /**
 Get Domain AltNames via domain
 */
-func getAltNames(domain string, d *gorm.DB) (altNamesRaw []byte, err error) {
+func getAltNames(domain string, d *gorm.DB) ([]byte, error) {
 	var altNames DomainAltname
-	if dbErr := d.Where(&DomainAltname{Domain: domain}).First(&altNames); dbErr != nil {
-		return altNamesRaw, errors.Wrapf(err, "GORM error %s", dbErr)
+	var altNamesRaw []byte
+	if d.Where(&DomainAltname{Domain: domain}).First(&altNames).RecordNotFound() {
+		altNamesRaw = []byte(altNames.Value)
+		return altNamesRaw, nil
 	}
 	altNamesRaw = []byte(altNames.Value)
-	return altNamesRaw, err
+	if dbErr := d.Where(&DomainAltname{Domain: domain}).First(&altNames).Error; dbErr != nil {
+		return altNamesRaw, errors.Wrapf(dbErr, "Unable to get alternate domains for %s", domain)
+	}
+	altNamesRaw = []byte(altNames.Value)
+	return altNamesRaw, nil
 }
 
 /**
 Get User Info via email
 */
-func getUserInfo(email string, d *gorm.DB) (userInfoRaw []byte, err error) {
+func getUserInfo(email string, d *gorm.DB) ([]byte, error) {
 	var userInfo UserInfo
-	if dbErr := d.Where(&UserInfo{Email: email}).Find(&userInfo); dbErr != nil {
-		return userInfoRaw, errors.Wrapf(err, "GORM error %s", dbErr)
+	var userInfoRaw []byte
+	if d.Where(&UserInfo{Email: email}).Find(&userInfo).RecordNotFound() {
+		userInfoRaw = []byte(userInfo.Value)
+		return userInfoRaw, nil
+	}
+	if dbErr := d.Where(&UserInfo{Email: email}).Find(&userInfo).Error; dbErr != nil {
+		return userInfoRaw, errors.Wrapf(dbErr, "Unable to get user info for %s", email)
 	}
 	userInfoRaw = []byte(userInfo.Value)
-	return userInfoRaw, err
+	return userInfoRaw, nil
 }
 
 /**
 Get Certificate Details via Domain
 */
-func getCertDetails(domain string, d *gorm.DB) (certDetailsRaw []byte, err error) {
+func getCertDetails(domain string, d *gorm.DB) ([]byte, error) {
 	var certDetails CertDetail
-	if dbErr := d.Where(&CertDetail{Domain: domain}).First(&certDetails); dbErr != nil {
-		return certDetailsRaw, errors.Wrapf(err, "GORM error %s", dbErr)
+	var certDetailsRaw []byte
+	if d.Where(&CertDetail{Domain: domain}).First(&certDetails).RecordNotFound() {
+		certDetailsRaw = []byte(certDetails.Value)
+		return certDetailsRaw, nil
+	}
+	if dbErr := d.Where(&CertDetail{Domain: domain}).First(&certDetails).Error; dbErr != nil {
+		return certDetailsRaw, errors.Wrapf(dbErr, "Unable to get certificate details for %s", domain)
 	}
 	certDetailsRaw = []byte(certDetails.Value)
-	return certDetailsRaw, err
+	return certDetailsRaw, nil
 }
 
 /**
 Save User Information key email, value userInfo
 */
-func addUserInfo(email string, userInfo []byte, d *gorm.DB) (err error) {
+func addUserInfo(email string, userInfo []byte, d *gorm.DB) error {
 	s := string(userInfo)
-	if dbErr := d.Create(&UserInfo{Email: email, Value: s}); dbErr != nil {
-		return errors.Wrapf(err, "GORM error %s", dbErr)
+	if dbErr := d.Create(&UserInfo{Email: email, Value: s}).Error; dbErr != nil {
+		return errors.Wrapf(dbErr, "Unable to add user info for %s", email)
 	}
-	return err
+	return nil
 }
 
 /**
 Save Certificate Details key domain, value certDetails
 */
-func addCertDetails(domain string, certDetails []byte, d *gorm.DB) (err error) {
+func addCertDetails(domain string, certDetails []byte, d *gorm.DB) error {
 	s := string(certDetails)
-	if dbErr := d.Create(&CertDetail{Domain: domain, Value: s}); dbErr != nil {
-		return errors.Wrapf(err, "GORM error %s", dbErr)
+	if dbErr := d.Create(&CertDetail{Domain: domain, Value: s}).Error; dbErr != nil {
+		return errors.Wrapf(dbErr, "Unable to add cert details for %s", domain)
 	}
-	return err
+	return nil
 }
 
 /**
 Save Alt Names Details key domain, value altNames
 */
-func addAltNames(domain string, altNames []byte, d *gorm.DB) (err error) {
+func addAltNames(domain string, altNames []byte, d *gorm.DB) error {
 	s := string(altNames)
-	if dbErr := d.Create(&DomainAltname{Domain: domain, Value: s}); dbErr != nil {
-		return errors.Wrapf(err, "GORM error %s", dbErr)
+	if dbErr := d.Create(&DomainAltname{Domain: domain, Value: s}).Error; dbErr != nil {
+		return errors.Wrapf(dbErr, "Unable to add alt names for %s", domain)
 	}
-	return err
+	return nil
 }
 
 /**
 Update Alt Names Details key domain, new values altNames
 */
-func updateAltNames(domain string, altNamesRaw []byte, d *gorm.DB) (err error) {
+func updateAltNames(domain string, altNamesRaw []byte, d *gorm.DB) error {
 	s := string(altNamesRaw)
 	var altNames DomainAltname
-	if dbErr := d.Where(&DomainAltname{Domain: domain}).First(&altNames); dbErr != nil {
-		return errors.Wrapf(err, "GORM error %s", dbErr)
+	if dbErr := d.Where(&DomainAltname{Domain: domain}).First(&altNames).Error; dbErr != nil {
+		return errors.Wrapf(dbErr, "Unable to update alt names for %s", domain)
 	}
 	altNames.Value = s
 	d.Save(&altNames)
-	return err
+	return nil
 }
 
 /**
 Update Certificate Details key domain, new value certDetails
 */
-func updateCertDetails(domain string, certDetailsRaw []byte, d *gorm.DB) (err error) {
+func updateCertDetails(domain string, certDetailsRaw []byte, d *gorm.DB) error {
 	s := string(certDetailsRaw)
 	var certDetails CertDetail
-	if dbErr := d.Where(&CertDetail{Domain: domain}).First(&certDetails); dbErr != nil {
-		return errors.Wrapf(err, "GORM error %s", dbErr)
+	if dbErr := d.Where(&CertDetail{Domain: domain}).First(&certDetails).Error; dbErr != nil {
+		return errors.Wrapf(dbErr, "Unable to update cert details for %s", domain)
 	}
 	certDetails.Value = s
 	d.Save(&certDetails)
-	return err
+	return nil
+}
+
+/**
+Wrapper function to either save or update depending on renewal flag
+*/
+func saveCertDetails(domain string, certDetailsRaw []byte, d *gorm.DB, isRenewal bool) error {
+	if isRenewal {
+		return updateCertDetails(domain, certDetailsRaw, d)
+	} else {
+		return addCertDetails(domain, certDetailsRaw, d)
+	}
+}
+
+/**
+Wrapper function to either save or update depending on renewal flag
+*/
+func saveAltNames(domain string, altNamesRaw []byte, d *gorm.DB, isRenewal bool) error {
+	if isRenewal {
+		return updateAltNames(domain, altNamesRaw, d)
+	} else {
+		return addAltNames(domain, altNamesRaw, d)
+	}
 }

--- a/db.go
+++ b/db.go
@@ -6,63 +6,135 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
 
-type test struct {
+type CertDetail struct {
 	gorm.Model
-	Cert string
+	Domain string `gorm:"unique"`
+	Value  string
 }
 
-func addCert(name string) {
+type DomainAltname struct {
+	gorm.Model
+	Domain string `gorm:"unique"`
+	Value  string
+}
+
+type UserInfo struct {
+	gorm.Model
+	Email string `gorm:"unique"`
+	Value string
+}
+
+func db() (*gorm.DB, error) {
+	fmt.Println("Calling to connect to DATABASE!!!!!")
 	db, err := gorm.Open("postgres", "host=localhost port=5432 user=certmanager dbname=certmanager password=Pass1234 sslmode=disable")
 	if err != nil {
 		fmt.Println(err)
 		panic("failed to connect to certManager database")
 	}
-	defer db.Close()
-	db.AutoMigrate(&test{})
 
-	//Add cert object
-	db.Create(&test{Cert: name})
-
+	return db, err
+	//defer db.Close()
 }
 
 /**
 Get Domain AltNames via domain
 */
 func getAltNames(domain string) (altNames []byte, err error) {
-	panic("Not Implemented")
+	fmt.Println("Callng the get AltNames function")
+	fmt.Println(domain)
+	d, err := db()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	d.Where(&DomainAltname{Domain: domain}).First(&altNames)
+	defer d.Close()
+	return altNames, err
 }
 
 /**
 Get User Info via email
 */
 func getUserInfo(email string) (userInfo []byte, err error) {
-	panic("Not Implemented")
+	fmt.Println("Calling the get UserInfo function")
+	fmt.Println(email)
+	d, err := db()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	d.Where(&UserInfo{Email: email}).First(&userInfo)
+	defer d.Close()
+	return userInfo, err
 }
 
 /**
 Get Certificate Details via Domain
 */
 func getCertDeatils(domain string) (certDetails []byte, err error) {
-	panic("Not Implemented")
+	fmt.Println("Calling the get cert Details function")
+	fmt.Println(domain)
+	d, err := db()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	d.Where(&CertDetail{Domain: domain}).First(&certDetails)
+	defer d.Close()
+	return certDetails, err
 }
 
 /**
 Save User Information key email, value userInfo
 */
 func addUserInfo(email string, userInfo []byte) error {
-	panic("Not Implemented")
+	fmt.Println("Calling the add user info function")
+	fmt.Println(email)
+
+	d, err := db()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	s := string(userInfo)
+	fmt.Println(s)
+	d.Create(&UserInfo{Email: email, Value: s})
+	defer d.Close()
+	return err
 }
 
 /**
 Save Certificate Details key domain, value certDetails
 */
 func addCertDetails(domain string, certDetails []byte) error {
-	panic("Not Implemented")
+	fmt.Println("Calling the add certDetails function")
+	fmt.Println(domain)
+	d, err := db()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	s := string(certDetails)
+	fmt.Println(s)
+	d.Create(&CertDetail{Domain: domain, Value: s})
+	defer d.Close()
+	return err
 }
 
 /**
 Save Alt Name Details key domain, value altNames
 */
 func addAltNames(domain string, altNames []byte) error {
-	panic("Not Implemented")
+	fmt.Println("Calling the add alt name function")
+	fmt.Println(domain)
+	d, err := db()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	s := string(altNames)
+	fmt.Println(s)
+	d.Create(&DomainAltname{Domain: domain, Value: s})
+	defer d.Close()
+	return err
 }

--- a/db.go
+++ b/db.go
@@ -127,10 +127,12 @@ func updateAltNames(domain string, altNamesRaw []byte, d *gorm.DB) error {
 	s := string(altNamesRaw)
 	var altNames DomainAltname
 	if dbErr := d.Where(&DomainAltname{Domain: domain}).First(&altNames).Error; dbErr != nil {
-		return errors.Wrapf(dbErr, "Unable to update alt names for %s", domain)
+		return errors.Wrapf(dbErr, "On update, unable to retrieve alt names for %s", domain)
 	}
 	altNames.Value = s
-	d.Save(&altNames)
+	if dbErr := d.Save(&altNames).Error; dbErr != nil {
+		return errors.Wrapf(dbErr, "Unable to update alt names for %s", domain)
+	}
 	return nil
 }
 
@@ -141,10 +143,12 @@ func updateCertDetails(domain string, certDetailsRaw []byte, d *gorm.DB) error {
 	s := string(certDetailsRaw)
 	var certDetails CertDetail
 	if dbErr := d.Where(&CertDetail{Domain: domain}).First(&certDetails).Error; dbErr != nil {
-		return errors.Wrapf(dbErr, "Unable to update cert details for %s", domain)
+		return errors.Wrapf(dbErr, "On update, unable to retrieve cert details for %s", domain)
 	}
 	certDetails.Value = s
-	d.Save(&certDetails)
+	if dbErr := d.Save(&certDetails).Error; dbErr != nil {
+		return errors.Wrapf(dbErr, "Unable to update cert details for %s", domain)
+	}
 	return nil
 }
 

--- a/db.go
+++ b/db.go
@@ -114,7 +114,7 @@ func addCertDetails(domain string, certDetails []byte) error {
 }
 
 /**
-Save Alt Name Details key domain, value altNames
+Save Alt Names Details key domain, value altNames
 */
 func addAltNames(domain string, altNames []byte) error {
 	log.Printf("Saving domain alt-names to database for domain (%s)", domain)
@@ -123,6 +123,42 @@ func addAltNames(domain string, altNames []byte) error {
 	s := string(altNames)
 
 	d.Create(&DomainAltname{Domain: domain, Value: s})
+	defer d.Close()
+
+	return err
+}
+
+/**
+Update Alt Names Details key domain, new values altNames
+*/
+func updateAltNames(domain string, altNamesRaw []byte) error {
+	log.Printf("Updating domain alt-names to database for domain (%s)", domain)
+
+	d, err := db()
+	s := string(altNamesRaw)
+	var altNames DomainAltname
+
+	d.Where(&DomainAltname{Domain: domain}).First(&altNames)
+	altNames.Value = s
+	d.Save(&altNames)
+	defer d.Close()
+
+	return err
+}
+
+/**
+Update Certificate Details key domain, new value certDetails
+*/
+func updateCertDetails(domain string, certDetailsRaw []byte) error {
+	log.Printf("Updating domain alt-names to database for domain (%s)", domain)
+
+	d, err := db()
+	s := string(certDetailsRaw)
+	var certDetails CertDetail
+
+	d.Where(&CertDetail{Domain: domain}).First(&certDetails)
+	certDetails.Value = s
+	d.Save(&certDetails)
 	defer d.Close()
 
 	return err

--- a/db.go
+++ b/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
+	"log"
 )
 
 type CertDetail struct {
@@ -39,67 +40,63 @@ func db() (*gorm.DB, error) {
 /**
 Get Domain AltNames via domain
 */
-func getAltNames(domain string) (altNames []byte, err error) {
-	fmt.Println("Callng the get AltNames function")
-	fmt.Println(domain)
+func getAltNames(domain string) (altNamesRaw []byte, err error) {
+	log.Printf("Retreving domain alt-names from database for domain (%s)", domain)
+
 	d, err := db()
-	if err != nil {
-		fmt.Println(err)
-	}
+	var altNames DomainAltname
 
 	d.Where(&DomainAltname{Domain: domain}).First(&altNames)
 	defer d.Close()
-	return altNames, err
+
+	altNamesRaw = []byte(altNames.Value)
+	return altNamesRaw, err
 }
 
 /**
 Get User Info via email
 */
-func getUserInfo(email string) (userInfo []byte, err error) {
-	fmt.Println("Calling the get UserInfo function")
-	fmt.Println(email)
-	d, err := db()
-	if err != nil {
-		fmt.Println(err)
-	}
+func getUserInfo(email string) (userInfoRaw []byte, err error) {
+	log.Printf("Retreving user info email (%s) from database", email)
 
-	d.Where(&UserInfo{Email: email}).First(&userInfo)
+	d, err := db()
+	var userInfo UserInfo
+
+	d.Where(&UserInfo{Email: email}).Find(&userInfo)
 	defer d.Close()
-	return userInfo, err
+
+	userInfoRaw = []byte(userInfo.Value)
+	return userInfoRaw, err
 }
 
 /**
 Get Certificate Details via Domain
 */
-func getCertDeatils(domain string) (certDetails []byte, err error) {
-	fmt.Println("Calling the get cert Details function")
-	fmt.Println(domain)
+func getCertDetails(domain string) (certDetailsRaw []byte, err error) {
+	log.Printf("Retreving certificate details from database for domain (%s)", domain)
+
 	d, err := db()
-	if err != nil {
-		fmt.Println(err)
-	}
+	var certDetails CertDetail
 
 	d.Where(&CertDetail{Domain: domain}).First(&certDetails)
 	defer d.Close()
-	return certDetails, err
+
+	certDetailsRaw = []byte(certDetails.Value)
+	return certDetailsRaw, err
 }
 
 /**
 Save User Information key email, value userInfo
 */
 func addUserInfo(email string, userInfo []byte) error {
-	fmt.Println("Calling the add user info function")
-	fmt.Println(email)
+	log.Printf("Saving user info email (%s) to database", email)
 
 	d, err := db()
-	if err != nil {
-		fmt.Println(err)
-	}
-
 	s := string(userInfo)
-	fmt.Println(s)
+
 	d.Create(&UserInfo{Email: email, Value: s})
 	defer d.Close()
+
 	return err
 }
 
@@ -107,17 +104,14 @@ func addUserInfo(email string, userInfo []byte) error {
 Save Certificate Details key domain, value certDetails
 */
 func addCertDetails(domain string, certDetails []byte) error {
-	fmt.Println("Calling the add certDetails function")
-	fmt.Println(domain)
-	d, err := db()
-	if err != nil {
-		fmt.Println(err)
-	}
+	log.Printf("Saving certificate details to database for domain (%s)", domain)
 
+	d, err := db()
 	s := string(certDetails)
-	fmt.Println(s)
+
 	d.Create(&CertDetail{Domain: domain, Value: s})
 	defer d.Close()
+
 	return err
 }
 
@@ -125,16 +119,13 @@ func addCertDetails(domain string, certDetails []byte) error {
 Save Alt Name Details key domain, value altNames
 */
 func addAltNames(domain string, altNames []byte) error {
-	fmt.Println("Calling the add alt name function")
-	fmt.Println(domain)
-	d, err := db()
-	if err != nil {
-		fmt.Println(err)
-	}
+	log.Printf("Saving domain alt-names to database for domain (%s)", domain)
 
+	d, err := db()
 	s := string(altNames)
-	fmt.Println(s)
+
 	d.Create(&DomainAltname{Domain: domain, Value: s})
 	defer d.Close()
+
 	return err
 }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -32,6 +32,8 @@ spec:
             - "-default-email=techdev-mwc@liquidweb.com"
             # If you set a default provider, you can omit the field/annotation from Certificates/Ingresses
             - "-default-provider=http"
+            # PostreSQL database hostname, port, user, password, sslmode
+            - "-db-args=host=localhost port=5432 user=certmanager dbname=certmanager password=Pass1234 sslmode=disable"
           volumeMounts:
             - name:  data-dir-vol
               mountPath: /var/lib/cert-manager

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,7 +18,6 @@ spec:
         - name: kube-cert-manager
           image: ctriv/kube-cert-manager:build-4
           args:
-            - "-data-dir=/var/lib/cert-manager"
             - "-acme-url=https://acme-staging.api.letsencrypt.org/directory"
             # NOTE: the URL above points to the staging server, where you won't get real certs.
             # Uncomment the line below to use the production LetsEncrypt server:
@@ -32,8 +31,18 @@ spec:
             - "-default-email=techdev-mwc@liquidweb.com"
             # If you set a default provider, you can omit the field/annotation from Certificates/Ingresses
             - "-default-provider=http"
-            # PostreSQL database hostname, port, user, password, sslmode
-            - "-db-args=host=localhost port=5432 user=certmanager dbname=certmanager password=Pass1234 sslmode=disable"
+            # PostreSQL database hostname
+            - "-db-host=localhost"
+            # PostreSQL database port
+            - "-db-port=5432"
+            # PostreSQL database username
+            - "-db-username=certmanager"
+            # PostreSQL database name
+            - "-db-name=certmanager"
+            # PostreSQL database password
+            - "-db-password=Pass1234"
+            # PostreSQL database sslmode
+            - "-db-sslmode=disable"
           volumeMounts:
             - name:  data-dir-vol
               mountPath: /var/lib/cert-manager

--- a/main.go
+++ b/main.go
@@ -86,9 +86,11 @@ func main() {
 	if acmeURL == "" {
 		log.Fatal("The acme-url command line parameter must be specified")
 	}
+	fmt.Println(acmeURL + " This is the current ACME URL ....")
+	addCert("shouldmaketable")
 
 	// Initialize bolt
-	if err := os.MkdirAll(dataDir, 0700); err != nil {
+	/*if err := os.MkdirAll(dataDir, 0700); err != nil {
 		log.Fatalf("Error while creating %v directory: %v", dataDir, err)
 	}
 
@@ -97,6 +99,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error while creating bolt database file at %v: %v", dbPath, err)
 	}
+
+
+		In this for loop it creates the buckets for the bolt db. We would no longer need this as
+		the bucketNames are now going to be the tables in postgres and should be persistent.
 
 	for _, bucketName := range []string{"user-info", "cert-details", "domain-altnames"} {
 		err = db.Update(func(tx *bolt.Tx) error {
@@ -110,7 +116,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Error while creating bolt bucket %v: %v", bucketName, err)
 		}
-	}
+	}*/
 
 	log.Println("Starting Kubernetes Certificate Controller...")
 

--- a/main.go
+++ b/main.go
@@ -173,6 +173,7 @@ func main() {
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	<-signalChan
 	log.Println("Shutdown signal received, exiting...")
+	p.db.Close()
 	close(doneChan)
 	wg.Wait()
 	return

--- a/processor.go
+++ b/processor.go
@@ -623,23 +623,13 @@ func (p *CertProcessor) processCertificate(cert Certificate, forMaint bool) (boo
 		return p.NoteCertError(cert, err, "Error while marshalling altNames for domain %v", cert.Spec.Domain)
 	}
 
-	//Need to distinguish if this is a new cert or a renewal.
-	if isRenewal {
-		err = updateCertDetails(cert.Spec.Domain, certDetailsRaw, p.db)
-	} else {
-		err = addCertDetails(cert.Spec.Domain, certDetailsRaw, p.db)
-	}
+	err = saveCertDetails(cert.Spec.Domain, certDetailsRaw, p.db, isRenewal)
 
 	if err != nil {
 		return p.NoteCertError(cert, err, "Error while saving certificate data to database for domain %v", cert.Spec.Domain)
 	}
 
-	//Need to distinguish if this is a new cert or a renewal.
-	if isRenewal {
-		err = updateAltNames(cert.Spec.Domain, altNamesRaw, p.db)
-	} else {
-		err = addAltNames(cert.Spec.Domain, altNamesRaw, p.db)
-	}
+	err = saveAltNames(cert.Spec.Domain, altNamesRaw, p.db, isRenewal)
 
 	if err != nil {
 		return p.NoteCertError(cert, err, "Error while saving domain alt-names data to database for domain %v", cert.Spec.Domain)

--- a/processor.go
+++ b/processor.go
@@ -18,7 +18,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"log"
 	"sort"
 	"strings"
@@ -369,8 +368,8 @@ func (p *CertProcessor) getStoredAltNames(cert Certificate) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error while fetching altnames from database for domain %v", cert.Spec.Domain)
 	}
-	fmt.Println(altNamesRaw == nil)
-	if altNamesRaw == nil {
+
+	if len(altNamesRaw) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
The cert manager will now use an external PostgreSQL DB to manage persistent data. New command line arg has been added to run service.

./kube-cert-manager -default-email=some@email.com -kubeconfig=/Users/user1/.kube/config -acme-url=http://localhost:4000/directory -data-dir=/Users/folder1/data -db-args="host=localhost port=5432 user=user1 dbname=certmanagerdb password=password sslmode=disable"'